### PR TITLE
Update hex packaged files

### DIFF
--- a/src/epam.app.src
+++ b/src/epam.app.src
@@ -31,7 +31,7 @@
   {mod,          {epam_app,[]}},
 
   %% hex.pm packaging:
-  {files, ["src/", "c_src/epam.c", "configure", "rebar.config", "rebar.config.script", "README.md", "LICENSE.txt"]},
+  {files, ["src/", "c_src/epam.c", "configure", "rebar.config", "rebar.config.script", "vars.config.in", "README.md", "LICENSE.txt"]},
   {licenses, ["Apache 2.0"]},
   {links, [{"Github", "https://github.com/processone/epam"}]}
 ]}.


### PR DESCRIPTION
'configure' and 'vars.config.in' are required to build as ejabberd
dependencies with rebar3